### PR TITLE
Basic認証の導入に関する設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,18 @@
 class ApplicationController < ActionController::Base
+
+  before_action :basic_auth if: :production?
+  protect_from_forgery with: :exception
+
+  private
+
+  def production?
+    Rails.env.production?
+  end
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
 
-  before_action :basic_auth if: :production?
+  before_action :basic_auth, if: :production?
   protect_from_forgery with: :exception
 
   private

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -58,3 +58,10 @@ namespace :deploy do
     invoke 'unicorn:restart'
   end
 end
+
+set :default_env, {
+  rbenv_root: "/usr/local/rbenv",
+  path: "/usr/local/rbenv/shims:/usr/local/rbenv/bin:$PATH",
+  BASIC_AUTH_USER: ENV["BASIC_AUTH_USER"],
+  BASIC_AUTH_PASSWORD: ENV["BASIC_AUTH_PASSWORD"]
+}

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -8,6 +8,8 @@
 # server "db.example.com", user: "deploy", roles: %w{db}
 server '13.114.37.243', user: 'ec2-user', roles: %w{app db web}
 
+set :rails_env, "production"
+set :unicorn_rack_env, "production"
 
 # role-based syntax
 # ==================


### PR DESCRIPTION
# what
・Application ControllerにBasic認証のメソッドを定義
・アクセスに必要な情報を、環境変数を用いてコード内の記述から除外

#why
・開発中のアプリケーションは既存サイトのクローンであるため、閲覧者を限定し、訪問者に対して誤解を与えないようにするため。